### PR TITLE
fix: 🎨 Set fetch time frame from 'starts_after' to 'starts_on_or_after' today

### DIFF
--- a/src/blocks/ucsc-events/edit.js
+++ b/src/blocks/ucsc-events/edit.js
@@ -101,7 +101,7 @@ export default function Edit( { attributes, setAttributes } ) {
 			}
 
 			url.searchParams.set('per_page', itemCount);
-            url.searchParams.set('starts_on_or_after', 'today');
+            url.searchParams.set('starts_after', 'yesterday');
 
 			const response = await fetch(url.toString(), {
 				method: 'GET',

--- a/src/blocks/ucsc-events/edit.js
+++ b/src/blocks/ucsc-events/edit.js
@@ -101,7 +101,7 @@ export default function Edit( { attributes, setAttributes } ) {
 			}
 
 			url.searchParams.set('per_page', itemCount);
-            url.searchParams.set('starts_after', 'today');
+            url.searchParams.set('starts_on_or_after', 'today');
 
 			const response = await fetch(url.toString(), {
 				method: 'GET',

--- a/ucsc-blocks.php
+++ b/ucsc-blocks.php
@@ -124,7 +124,7 @@ if ( ! function_exists( 'ucsc_events_fetch_data' ) ) {
 		// Prepare API URL with per_page parameter
 		$full_url = add_query_arg( array(
 			'per_page' => absint( $per_page ),
-            'starts_on_or_after' => 'today'
+            'starts_after' => 'yesterday'
 		), $api_url );
 
 		// Fetch data from API

--- a/ucsc-blocks.php
+++ b/ucsc-blocks.php
@@ -124,7 +124,7 @@ if ( ! function_exists( 'ucsc_events_fetch_data' ) ) {
 		// Prepare API URL with per_page parameter
 		$full_url = add_query_arg( array(
 			'per_page' => absint( $per_page ),
-            'starts_after' => 'today'
+            'starts_on_or_after' => 'today'
 		), $api_url );
 
 		// Fetch data from API


### PR DESCRIPTION
Fixes #4

Site owners requested that events starting *today* should show up in the block.

While it will be possible that events show up after "today," owners insisted they are OK with that scenario.