### PR TITLE
refactor: Extract ucsc-events block PHP into block directory (#2)

### DIFF
--- a/src/blocks/ucsc-events/ucsc-events.php
+++ b/src/blocks/ucsc-events/ucsc-events.php
@@ -1,0 +1,165 @@
+<?php
+/**
+ * Server-side functions for the UCSC Events block.
+ *
+ * @package UcscBlocks
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Enqueue scripts for the block editor
+ */
+function ucsc_events_enqueue_block_editor_assets() {
+	wp_localize_script(
+		'ucsc-events-editor-script',
+		'ucscEventsData',
+		array(
+			'nonce' => wp_create_nonce('ucsc_events_nonce'),
+			'ajaxUrl' => admin_url('admin-ajax.php')
+		)
+	);
+}
+add_action( 'enqueue_block_editor_assets', 'ucsc_events_enqueue_block_editor_assets' );
+
+/**
+ * Add nonce to frontend
+ */
+function ucsc_events_enqueue_frontend_assets() {
+	if (has_block('ucsc/events')) {
+		wp_add_inline_script(
+			'wp-block-ucsc-events-view-script',
+			'window.ucscEventsNonce = ' . json_encode(wp_create_nonce('ucsc_events_nonce')) . ';\n' .
+			'window.ajaxurl = ' . json_encode(admin_url('admin-ajax.php')) . ';',
+			'before'
+		);
+	}
+}
+add_action( 'wp_enqueue_scripts', 'ucsc_events_enqueue_frontend_assets' );
+
+/**
+ * Handle cache clearing AJAX request
+ */
+function ucsc_events_clear_cache() {
+	// Verify nonce for security
+	if ( ! isset($_POST['nonce']) || ! wp_verify_nonce( $_POST['nonce'], 'ucsc_events_nonce' ) ) {
+		wp_send_json_error( array( 'message' => 'Security check failed' ) );
+		return;
+	}
+
+	// Check user permissions
+	if ( ! current_user_can( 'edit_posts' ) ) {
+		wp_send_json_error( array( 'message' => 'Insufficient permissions to clear the cache' ) );
+		return;
+	}
+
+	$api_url = isset($_POST['api_url']) ? sanitize_url( $_POST['api_url'] ) : '';
+
+	if ( ! empty( $api_url ) ) {
+		// Clear cache for different item counts
+		for ( $i = 1; $i <= 40; $i++ ) {
+			$cache_key = 'ucsc_events_' . md5( $api_url . $i );
+			delete_transient( $cache_key );
+		}
+
+		wp_send_json_success( array( 'message' => 'Cache cleared successfully' ) );
+	} else {
+		wp_send_json_error( array( 'message' => 'Invalid API URL' ) );
+	}
+}
+add_action( 'wp_ajax_ucsc_events_clear_cache', 'ucsc_events_clear_cache' );
+
+/**
+ * Fetch events data from external API
+ */
+if ( ! function_exists( 'ucsc_events_fetch_data' ) ) {
+	function ucsc_events_fetch_data( $api_url, $per_page = 6 ) {
+		if ( empty( $api_url ) ) {
+			return array();
+		}
+
+		// Create cache key based on URL and per_page
+		$cache_key = 'ucsc_events_' . md5( $api_url . $per_page );
+
+		// Try to get cached data first
+		$cached_data = get_transient( $cache_key );
+		if ( false !== $cached_data ) {
+			return $cached_data;
+		}
+
+		// Validate URL
+		if ( ! filter_var( $api_url, FILTER_VALIDATE_URL ) ) {
+			return array();
+		}
+
+		// Prepare API URL with per_page parameter
+		$full_url = add_query_arg( array(
+			'per_page' => absint( $per_page ),
+            'starts_after' => 'yesterday'
+		), $api_url );
+
+		// Fetch data from API
+		$response = wp_remote_get( $full_url, array(
+			'timeout' => 8,
+			'headers' => array(
+				'User-Agent' => 'UCSC Events Block/1.0',
+				'Accept' => 'application/json'
+			),
+			'sslverify' => true
+		) );
+
+		if ( is_wp_error( $response ) ) {
+			// Log error for debugging
+			error_log( 'UCSC Events API Error: ' . $response->get_error_message() );
+			return array();
+		}
+
+		$response_code = wp_remote_retrieve_response_code( $response );
+		if ( $response_code !== 200 ) {
+			error_log( 'UCSC Events API Error: HTTP ' . $response_code );
+			return array();
+		}
+
+		$body = wp_remote_retrieve_body( $response );
+		$fetched = json_decode( $body, true );
+		$data = $fetched['events'];
+
+		if ( ! is_array( $data ) ) {
+			error_log( 'UCSC Events API Error: Invalid JSON response' );
+			return array();
+		}
+
+		// Process and clean the data
+		$events = array();
+		foreach ( $data as $item ) {
+			if ( ! is_array( $item ) ) {
+				continue;
+			}
+
+			$featured_image = '';
+
+			// Try to get featured image from _embedded data
+			if ( isset( $item['image']['url'] ) ) {
+				$featured_image = $item['image']['url'];
+			} elseif ( isset( $item['image']['sizes']['medium']['url'] ) ) {
+				$featured_image = $item['image']['sizes']['medium']['url'];
+			}
+
+			$events[] = array(
+				'title' => isset( $item['title'] ) ? $item['title'] : 'Untitled',
+				'organizer' => isset( $item['organizer']['organizer'] ) ? $item['organizer']['organizer'] : '',
+				'date' => isset( $item['start_date'] ) ? date_i18n( get_option( 'date_format' ), strtotime( $item['start_date'] ) ) : '',
+				'venue' => isset( $item['venue']['venue'] ) ? $item['venue']['venue'] : '',
+				'featured_image' => $featured_image,
+				'link' => isset( $item['url'] ) ? $item['url'] : ''
+			);
+		}
+
+		// Cache the processed data for 15 minutes
+		set_transient( $cache_key, $events, HOUR_IN_SECONDS );
+
+		return $events;
+	}
+}

--- a/ucsc-blocks.php
+++ b/ucsc-blocks.php
@@ -37,156 +37,16 @@ function ucsc_blocks_init() {
 add_action( 'init', 'ucsc_blocks_init' );
 
 /**
- * Enqueue scripts for the block editor
+ * Load block-specific server-side PHP files.
  */
-function ucsc_events_enqueue_block_editor_assets() {
-	wp_localize_script(
-		'ucsc-events-editor-script',
-		'ucscEventsData',
-		array(
-			'nonce' => wp_create_nonce('ucsc_events_nonce'),
-			'ajaxUrl' => admin_url('admin-ajax.php')
-		)
-	);
-}
-add_action( 'enqueue_block_editor_assets', 'ucsc_events_enqueue_block_editor_assets' );
+$ucsc_blocks_dir = __DIR__ . '/build/blocks/';
+$ucsc_block_includes = array(
+	'ucsc-events/ucsc-events.php',
+);
 
-/**
- * Add nonce to frontend
- */
-function ucsc_events_enqueue_frontend_assets() {
-	if (has_block('ucsc/events')) {
-		wp_add_inline_script(
-			'wp-block-ucsc-events-view-script',
-			'window.ucscEventsNonce = ' . json_encode(wp_create_nonce('ucsc_events_nonce')) . ';\n' .
-			'window.ajaxurl = ' . json_encode(admin_url('admin-ajax.php')) . ';',
-			'before'
-		);
-	}
-}
-add_action( 'wp_enqueue_scripts', 'ucsc_events_enqueue_frontend_assets' );
-
-/**
- * Handle cache clearing AJAX request
- */
-function ucsc_events_clear_cache() {
-	// Verify nonce for security
-	if ( ! isset($_POST['nonce']) || ! wp_verify_nonce( $_POST['nonce'], 'ucsc_events_nonce' ) ) {
-		wp_send_json_error( array( 'message' => 'Security check failed' ) );
-		return;
-	}
-
-	// Check user permissions
-	if ( ! current_user_can( 'edit_posts' ) ) {
-		wp_send_json_error( array( 'message' => 'Insufficient permissions to clear the cache' ) );
-		return;
-	}
-
-	$api_url = isset($_POST['api_url']) ? sanitize_url( $_POST['api_url'] ) : '';
-	
-	if ( ! empty( $api_url ) ) {
-		// Clear cache for different item counts
-		for ( $i = 1; $i <= 40; $i++ ) {
-			$cache_key = 'ucsc_events_' . md5( $api_url . $i );
-			delete_transient( $cache_key );
-		}
-		
-		wp_send_json_success( array( 'message' => 'Cache cleared successfully' ) );
-	} else {
-		wp_send_json_error( array( 'message' => 'Invalid API URL' ) );
-	}
-}
-add_action( 'wp_ajax_ucsc_events_clear_cache', 'ucsc_events_clear_cache' );
-
-/**
- * Fetch events data from external API
- */
-if ( ! function_exists( 'ucsc_events_fetch_data' ) ) {
-	function ucsc_events_fetch_data( $api_url, $per_page = 6 ) {
-		if ( empty( $api_url ) ) {
-			return array();
-		}
-
-		// Create cache key based on URL and per_page
-		$cache_key = 'ucsc_events_' . md5( $api_url . $per_page );
-		
-		// Try to get cached data first
-		$cached_data = get_transient( $cache_key );
-		if ( false !== $cached_data ) {
-			return $cached_data;
-		}
-
-		// Validate URL
-		if ( ! filter_var( $api_url, FILTER_VALIDATE_URL ) ) {
-			return array();
-		}
-
-		// Prepare API URL with per_page parameter
-		$full_url = add_query_arg( array(
-			'per_page' => absint( $per_page ),
-            'starts_after' => 'yesterday'
-		), $api_url );
-
-		// Fetch data from API
-		$response = wp_remote_get( $full_url, array(
-			'timeout' => 8,
-			'headers' => array(
-				'User-Agent' => 'UCSC Events Block/1.0',
-				'Accept' => 'application/json'
-			),
-			'sslverify' => true
-		) );
-
-		if ( is_wp_error( $response ) ) {
-			// Log error for debugging
-			error_log( 'UCSC Events API Error: ' . $response->get_error_message() );
-			return array();
-		}
-
-		$response_code = wp_remote_retrieve_response_code( $response );
-		if ( $response_code !== 200 ) {
-			error_log( 'UCSC Events API Error: HTTP ' . $response_code );
-			return array();
-		}
-
-		$body = wp_remote_retrieve_body( $response );
-		$fetched = json_decode( $body, true );
-		$data = $fetched['events'];
-
-		if ( ! is_array( $data ) ) {
-			error_log( 'UCSC Events API Error: Invalid JSON response' );
-			return array();
-		}
-
-		// Process and clean the data
-		$events = array();
-		foreach ( $data as $item ) {
-			if ( ! is_array( $item ) ) {
-				continue;
-			}
-
-			$featured_image = '';
-			
-			// Try to get featured image from _embedded data
-			if ( isset( $item['image']['url'] ) ) {
-				$featured_image = $item['image']['url'];
-			} elseif ( isset( $item['image']['sizes']['medium']['url'] ) ) {
-				$featured_image = $item['image']['sizes']['medium']['url'];
-			}
-
-			$events[] = array(
-				'title' => isset( $item['title'] ) ? $item['title'] : 'Untitled',
-				'organizer' => isset( $item['organizer']['organizer'] ) ? $item['organizer']['organizer'] : '',
-				'date' => isset( $item['start_date'] ) ? date_i18n( get_option( 'date_format' ), strtotime( $item['start_date'] ) ) : '',
-				'venue' => isset( $item['venue']['venue'] ) ? $item['venue']['venue'] : '',
-				'featured_image' => $featured_image,
-				'link' => isset( $item['url'] ) ? $item['url'] : ''
-			);
-		}
-
-		// Cache the processed data for 15 minutes
-		set_transient( $cache_key, $events, HOUR_IN_SECONDS );
-
-		return $events;
+foreach ( $ucsc_block_includes as $include ) {
+	$file = $ucsc_blocks_dir . $include;
+	if ( file_exists( $file ) ) {
+		require_once $file;
 	}
 }


### PR DESCRIPTION
This PR is purely a refactor. Events Block specific code was moved from the main file into a php file within the `ucsc-events` block directory. The change should not affect block functionality.

To test this, run `npm start` in this branch and then use the block as you normally would. Previous instances of the block should work the same, and new instances of the block should work without issue.

Move event-specific server-side functions out of the main plugin file into src/blocks/ucsc-events/ucsc-events.php for better modularity.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>