### PR TITLE
[events] Add hide repeating events toggle and series indicator to events block

### DIFF
--- a/src/blocks/ucsc-events/block.json
+++ b/src/blocks/ucsc-events/block.json
@@ -27,6 +27,10 @@
 		"layoutStyle": {
 			"type": "string",
 			"default": "list"
+		},
+		"hideRepeating": {
+			"type": "boolean",
+			"default": false
 		}
 	},
 	"supports": {

--- a/src/blocks/ucsc-events/edit.js
+++ b/src/blocks/ucsc-events/edit.js
@@ -17,10 +17,11 @@ import { useBlockProps, InspectorControls, BlockControls } from '@wordpress/bloc
  * WordPress dependencies
  */
 import { 
-	PanelBody, 
-	TextControl, 
-	RangeControl, 
-	SelectControl, 
+	PanelBody,
+	TextControl,
+	RangeControl,
+	SelectControl,
+	ToggleControl,
 	Button,
 	Notice,
 	ToolbarGroup,
@@ -52,7 +53,7 @@ import './editor.scss';
  * @return {Element} Element to render.
  */
 export default function Edit( { attributes, setAttributes } ) {
-	const { apiUrl, itemCount, layoutStyle } = attributes;
+	const { apiUrl, itemCount, layoutStyle, hideRepeating } = attributes;
 	const [previewData, setPreviewData] = useState([]);
 	const [isLoading, setIsLoading] = useState(false);
 	const [error, setError] = useState('');
@@ -68,7 +69,8 @@ export default function Edit( { attributes, setAttributes } ) {
 		{ label: __('Cards', 'ucsc-events'), value: 'cards' }
 	];
 
-	// Fetch preview data when API URL or item count changes (debounced)
+	// Fetch preview data when API URL changes (debounced).
+	// Always fetches 50 events; itemCount is applied locally when rendering.
 	useEffect(() => {
 		if (!apiUrl) {
 			setPreviewData([]);
@@ -76,14 +78,14 @@ export default function Edit( { attributes, setAttributes } ) {
 			return;
 		}
 
-		// Debounce API calls - wait 500ms after user stops typing
+		// Debounce API calls - wait 1s after user stops typing
 		const timeoutId = setTimeout(() => {
 			fetchPreviewData();
 		}, 1000);
 
 		// Cleanup function to cancel the timeout if apiUrl changes again
 		return () => clearTimeout(timeoutId);
-	}, [apiUrl, itemCount]);
+	}, [apiUrl]);
 
 	const fetchPreviewData = async () => {
 		if (!apiUrl) return;
@@ -100,8 +102,8 @@ export default function Edit( { attributes, setAttributes } ) {
 				throw new Error(__('Please enter a valid URL', 'ucsc-events'));
 			}
 
-			url.searchParams.set('per_page', itemCount);
-            url.searchParams.set('starts_after', 'yesterday');
+			url.searchParams.set('per_page', 50);
+			url.searchParams.set('starts_after', 'yesterday');
 
 			const response = await fetch(url.toString(), {
 				method: 'GET',
@@ -140,7 +142,8 @@ export default function Edit( { attributes, setAttributes } ) {
 				date: dateI18n('F, j, Y', item.start_date) || '',
 				venue: item.venue?.venue || '',
 				featured_image: item.image?.url || '',
-				link: item.url || ''
+				link: item.url || '',
+				slug: item.slug || ''
 			}));
 
 			setPreviewData(processedData);
@@ -196,6 +199,36 @@ export default function Edit( { attributes, setAttributes } ) {
 		return tmp.textContent || tmp.innerText || '';
 	};
 
+	/**
+	 * Filter out duplicate events based on slug.
+	 * Since the API returns events sorted by date, the first occurrence
+	 * of each slug is the nearest upcoming instance.
+	 */
+	const deduplicateEvents = (events) => {
+		const seen = new Set();
+		return events.filter((event) => {
+			if (!event.slug) return true;
+			if (seen.has(event.slug)) return false;
+			seen.add(event.slug);
+			return true;
+		});
+	};
+
+	// Identify slugs that appear more than once (series/repeating events)
+	const seriesSlugs = new Set();
+	const slugCounts = {};
+	previewData.forEach((event) => {
+		if (event.slug) {
+			slugCounts[event.slug] = (slugCounts[event.slug] || 0) + 1;
+		}
+	});
+	Object.entries(slugCounts).forEach(([slug, count]) => {
+		if (count > 1) seriesSlugs.add(slug);
+	});
+
+	const dedupedData = hideRepeating ? deduplicateEvents(previewData) : previewData;
+	const displayData = dedupedData.slice(0, itemCount);
+
 	const renderEventItem = (event, index) => (
 		<div key={index} className="ucsc-event-item">
 			{event.featured_image && (
@@ -216,6 +249,12 @@ export default function Edit( { attributes, setAttributes } ) {
 				{event.date && (
 					<div className="ucsc-event-date">
 						{stripHTMLTags(event.date)}
+					</div>
+				)}
+				{event.slug && seriesSlugs.has(event.slug) && (
+					<div className="ucsc-event-series">
+						<span className="dashicons dashicons-controls-repeat"></span>
+						{__('Series', 'ucsc-events')}
 					</div>
 				)}
 				{event.venue && (
@@ -275,6 +314,13 @@ export default function Edit( { attributes, setAttributes } ) {
 						help={__('Choose how events should be displayed', 'ucsc-events')}
 					/>
 
+					<ToggleControl
+						label={__('Hide repeating events', 'ucsc-events')}
+						checked={hideRepeating}
+						onChange={(value) => setAttributes({ hideRepeating: value })}
+						help={__('Show only the next upcoming instance of each repeating event.', 'ucsc-events')}
+					/>
+
 					<div className="ucsc-events-cache-controls">
 						<Button
 							variant="secondary"
@@ -316,15 +362,15 @@ export default function Edit( { attributes, setAttributes } ) {
 					</Notice>
 				)}
 
-				{apiUrl && !isLoading && !error && previewData.length === 0 && (
+				{apiUrl && !isLoading && !error && displayData.length === 0 && (
 					<Notice status="warning" isDismissible={false}>
 						{__('No items found at the specified URL.', 'ucsc-events')}
 					</Notice>
 				)}
 
-				{apiUrl && !isLoading && !error && previewData.length > 0 && (
+				{apiUrl && !isLoading && !error && displayData.length > 0 && (
 					<div className="ucsc-events-list">
-						{previewData.map(renderEventItem)}
+						{displayData.map(renderEventItem)}
 					</div>
 				)}
 			</div>

--- a/src/blocks/ucsc-events/render.php
+++ b/src/blocks/ucsc-events/render.php
@@ -7,17 +7,52 @@
 $api_url = $attributes['apiUrl'] ?? '';
 $item_count = $attributes['itemCount'] ?? 6;
 $layout_style = $attributes['layoutStyle'] ?? 'list';
+$hide_repeating = $attributes['hideRepeating'] ?? false;
 
 // Get the block wrapper attributes with layout class
 $wrapper_attributes = get_block_wrapper_attributes(array(
 	'class' => 'layout-' . esc_attr($layout_style)
 ));
 
-// Fetch events data
+// Fetch all cached events (up to 50 from the API)
 $events = array();
+$series_slugs = array();
 if (!empty($api_url)) {
 	if (function_exists('ucsc_events_fetch_data')) {
-		$events = ucsc_events_fetch_data($api_url, $item_count);
+		$events = ucsc_events_fetch_data($api_url);
+
+		// Identify slugs that appear more than once (i.e. repeating/series events).
+		// Built from the full dataset before any filtering or slicing.
+		$slug_counts = array();
+		foreach ($events as $event) {
+			$slug = $event['slug'] ?? '';
+			if (!empty($slug)) {
+				$slug_counts[$slug] = ($slug_counts[$slug] ?? 0) + 1;
+			}
+		}
+		$series_slugs = array_filter($slug_counts, function ($count) {
+			return $count > 1;
+		});
+
+		// Filter out repeating events, keeping only the nearest upcoming instance.
+		// Events are returned sorted by date, so the first occurrence of each slug wins.
+		if ($hide_repeating && !empty($events)) {
+			$seen_slugs = array();
+			$events = array_filter($events, function ($event) use (&$seen_slugs) {
+				$slug = $event['slug'] ?? '';
+				if (empty($slug)) {
+					return true;
+				}
+				if (isset($seen_slugs[$slug])) {
+					return false;
+				}
+				$seen_slugs[$slug] = true;
+				return true;
+			});
+		}
+
+		// Slice to the requested number of events
+		$events = array_slice($events, 0, $item_count);
 	}
 }
 
@@ -66,6 +101,13 @@ if (!wp_script_is('ucsc-events-frontend', 'done')) {
 						<?php if (!empty($event['date'])): ?>
 							<div class="ucsc-event-date">
 								<?php echo wp_kses_post($event['date']); ?>
+							</div>
+						<?php endif; ?>
+
+						<?php if (isset($series_slugs[$event['slug'] ?? ''])): ?>
+							<div class="ucsc-event-series">
+								<span class="dashicons dashicons-controls-repeat"></span>
+								<?php _e('Series', 'ucsc-events'); ?>
 							</div>
 						<?php endif; ?>
 

--- a/src/blocks/ucsc-events/style.scss
+++ b/src/blocks/ucsc-events/style.scss
@@ -141,6 +141,21 @@
 		}
 	}
 
+	.ucsc-event-series {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.25rem;
+		margin-bottom: 0.5rem;
+		font-size: 0.8rem;
+		color: #555;
+
+		.dashicons {
+			font-size: 1rem;
+			width: 1rem;
+			height: 1rem;
+		}
+	}
+
 	.ucsc-event-excerpt {
 		margin: 0;
 		font-size: 0.95rem;

--- a/src/blocks/ucsc-events/ucsc-events.php
+++ b/src/blocks/ucsc-events/ucsc-events.php
@@ -29,6 +29,7 @@ add_action( 'enqueue_block_editor_assets', 'ucsc_events_enqueue_block_editor_ass
  */
 function ucsc_events_enqueue_frontend_assets() {
 	if (has_block('ucsc/events')) {
+		wp_enqueue_style('dashicons');
 		wp_add_inline_script(
 			'wp-block-ucsc-events-view-script',
 			'window.ucscEventsNonce = ' . json_encode(wp_create_nonce('ucsc_events_nonce')) . ';\n' .
@@ -58,11 +59,8 @@ function ucsc_events_clear_cache() {
 	$api_url = isset($_POST['api_url']) ? sanitize_url( $_POST['api_url'] ) : '';
 
 	if ( ! empty( $api_url ) ) {
-		// Clear cache for different item counts
-		for ( $i = 1; $i <= 40; $i++ ) {
-			$cache_key = 'ucsc_events_' . md5( $api_url . $i );
-			delete_transient( $cache_key );
-		}
+		$cache_key = 'ucsc_events_' . md5( $api_url );
+		delete_transient( $cache_key );
 
 		wp_send_json_success( array( 'message' => 'Cache cleared successfully' ) );
 	} else {
@@ -72,16 +70,19 @@ function ucsc_events_clear_cache() {
 add_action( 'wp_ajax_ucsc_events_clear_cache', 'ucsc_events_clear_cache' );
 
 /**
- * Fetch events data from external API
+ * Fetch events data from external API.
+ *
+ * Always fetches the maximum 50 events from the API and caches them.
+ * Callers are responsible for slicing the result to the desired count.
  */
 if ( ! function_exists( 'ucsc_events_fetch_data' ) ) {
-	function ucsc_events_fetch_data( $api_url, $per_page = 6 ) {
+	function ucsc_events_fetch_data( $api_url ) {
 		if ( empty( $api_url ) ) {
 			return array();
 		}
 
-		// Create cache key based on URL and per_page
-		$cache_key = 'ucsc_events_' . md5( $api_url . $per_page );
+		// Create cache key based on URL only
+		$cache_key = 'ucsc_events_' . md5( $api_url );
 
 		// Try to get cached data first
 		$cached_data = get_transient( $cache_key );
@@ -94,10 +95,10 @@ if ( ! function_exists( 'ucsc_events_fetch_data' ) ) {
 			return array();
 		}
 
-		// Prepare API URL with per_page parameter
+		// Always fetch the maximum number of events (API caps at 50)
 		$full_url = add_query_arg( array(
-			'per_page' => absint( $per_page ),
-            'starts_after' => 'yesterday'
+			'per_page'     => 50,
+			'starts_after' => 'yesterday'
 		), $api_url );
 
 		// Fetch data from API
@@ -153,7 +154,8 @@ if ( ! function_exists( 'ucsc_events_fetch_data' ) ) {
 				'date' => isset( $item['start_date'] ) ? date_i18n( get_option( 'date_format' ), strtotime( $item['start_date'] ) ) : '',
 				'venue' => isset( $item['venue']['venue'] ) ? $item['venue']['venue'] : '',
 				'featured_image' => $featured_image,
-				'link' => isset( $item['url'] ) ? $item['url'] : ''
+				'link' => isset( $item['url'] ) ? $item['url'] : '',
+				'slug' => isset( $item['slug'] ) ? $item['slug'] : ''
 			);
 		}
 


### PR DESCRIPTION
Fixes #6 

- Add hideRepeating boolean attribute to block.json
- Add slug field to event data in PHP fetch and JS preview
- Always fetch 50 events from API (the max) and cache by URL only
- Apply slug-based deduplication when hideRepeating is enabled
- Slice to itemCount after dedup so count is always respected
- Add ToggleControl in editor sidebar for the setting
- Add series badge (repeat icon + 'Series' label) on events whose slug appears more than once in the full dataset
- Enqueue dashicons on frontend for series indicator
- Simplify cache clearing to use single key per URL